### PR TITLE
Rewrite in order to use the  HttpClient instead of URLConnection

### DIFF
--- a/src/main/java/org/broadinstitute/http/nio/HttpFileSystemProviderSettings.java
+++ b/src/main/java/org/broadinstitute/http/nio/HttpFileSystemProviderSettings.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.http.nio;
 
 import java.net.Proxy;
+import java.net.http.HttpClient;
+import java.time.Duration;
 
 /**
  * Settings that control the behavior of newly instantiated Http(s)FileSystems
@@ -8,10 +10,10 @@ import java.net.Proxy;
  * WARNING: These currently don't seem to be used anywhere...
  * @param proxy Proxy to use when making connections
  * @param useCaching should caching be enabled
- * @param timeout timeout in seconds
+ * @param timeout timeout duration
  * @param maxRetries max number of retries before throwing an error
  */
-public record HttpFileSystemProviderSettings( Proxy proxy, boolean useCaching, int timeout, int maxRetries ){
+public record HttpFileSystemProviderSettings(Proxy proxy, boolean useCaching, Duration timeout, int maxRetries, HttpClient.Redirect redirect){
     /** default settings which will be used unless they are reset */
-    public static final HttpFileSystemProviderSettings DEFAULT_SETTINGS = new HttpFileSystemProviderSettings(null, false, 10, 3);
+    public static final HttpFileSystemProviderSettings DEFAULT_SETTINGS = new HttpFileSystemProviderSettings(null, false, Duration.ofSeconds(10), 3, HttpClient.Redirect.NORMAL);
 }

--- a/src/test/java/org/broadinstitute/http/nio/BaseTest.java
+++ b/src/test/java/org/broadinstitute/http/nio/BaseTest.java
@@ -6,7 +6,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 
@@ -45,12 +46,12 @@ public class BaseTest {
      * @return URL string in GitHub-pages.
      *
      * @throws AssertionError if the URL is malformed (unexpected).
-     * @see #getGithubPagesFileUrl(String)
+     * @see #getGithubPagesFileUri(String)
      */
-    public static URL getGithubPagesFileUrl(final String baseName) {
+    public static URI getGithubPagesFileUri(final String baseName) {
         try {
-            return new URL(getGithubPagesFullUrlName(baseName));
-        } catch (MalformedURLException e) {
+            return new URI(getGithubPagesFullUrlName(baseName));
+        } catch (URISyntaxException e) {
             throw new AssertionError("Unexpected error for GitHub file " + baseName, e);
         }
     }
@@ -88,12 +89,12 @@ public class BaseTest {
      *
      * <p>WARNING: do not use with huge files.
      *
-     * @param httpUrl URL to read.
+     * @param httpUri URL to read.
      *
      * @return byte array containing all the bytes in the file.
      */
-    public static byte[] readAllBytes(final URL httpUrl) throws Exception {
-        final HttpURLConnection connection = (HttpURLConnection) httpUrl.openConnection();
+    public static byte[] readAllBytes(final URI httpUri) throws Exception {
+        final HttpURLConnection connection = (HttpURLConnection) httpUri.toURL().openConnection();
         try {
             // open the connection and the input stream
             // open the connection and try to guess the length of the output

--- a/src/test/java/org/broadinstitute/http/nio/GitHubResourcesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/http/nio/GitHubResourcesIntegrationTest.java
@@ -28,7 +28,7 @@ public class GitHubResourcesIntegrationTest extends BaseTest {
     @Test(dataProvider = "getDocsFilesForTesting")
     public void testGitHubResourcesExists(final String fileName) throws Exception {
         final HttpURLConnection connection = (HttpURLConnection)
-                getGithubPagesFileUrl(fileName).openConnection();
+                getGithubPagesFileUri(fileName).toURL().openConnection();
         try {
             connection.setRequestMethod("GET");
             connection.connect();
@@ -48,7 +48,7 @@ public class GitHubResourcesIntegrationTest extends BaseTest {
         // 1. read the local file
         final byte[] local = Files.readAllBytes(getLocalDocsFilePath(fileName));
         // 2. read the GitHub-pages file
-        final byte[] github = readAllBytes(getGithubPagesFileUrl(fileName));
+        final byte[] github = readAllBytes(getGithubPagesFileUri(fileName));
 
         // assert that the same bytes were read
         Assert.assertEquals(github, local);

--- a/src/test/java/org/broadinstitute/http/nio/HttpAbstractFileSystemProviderUnitTest.java
+++ b/src/test/java/org/broadinstitute/http/nio/HttpAbstractFileSystemProviderUnitTest.java
@@ -10,7 +10,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.file.AccessDeniedException;
 import java.nio.file.AccessMode;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystemNotFoundException;
@@ -159,24 +158,24 @@ public class HttpAbstractFileSystemProviderUnitTest extends BaseTest {
     }
 
     @DataProvider
-    public Object[][] deniedAccess() {
+    public Object[][] readOnly() {
         return new Object[][] {
             {AccessMode.EXECUTE},
             {AccessMode.WRITE}
         };
     }
 
-    @Test(dataProvider= "deniedAccess", expectedExceptions = AccessDeniedException.class)
-    public void testCheckAccessDenied(final AccessMode deniedAcces) throws Exception {
+    @Test(dataProvider= "readOnly", expectedExceptions = UnsupportedOperationException.class)
+    public void testReadOnly(final AccessMode deniedAcces) throws Exception {
         final HttpsFileSystemProvider https = new HttpsFileSystemProvider();
-        final HttpPath path = https.getPath(getGithubPagesFileUrl("file1.txt").toURI());
+        final HttpPath path = https.getPath(getGithubPagesFileUri("file1.txt"));
         https.checkAccess(path, deniedAcces);
     }
 
     @Test
     public void testCheckAccessRead() throws Exception {
         final HttpsFileSystemProvider https = new HttpsFileSystemProvider();
-        final HttpPath path = https.getPath(getGithubPagesFileUrl("file1.txt").toURI());
+        final HttpPath path = https.getPath(getGithubPagesFileUri("file1.txt"));
         // this shouldn't throw
         https.checkAccess(path, AccessMode.READ);
     }
@@ -184,7 +183,7 @@ public class HttpAbstractFileSystemProviderUnitTest extends BaseTest {
     @Test(expectedExceptions = NoSuchFileException.class)
     public void testCheckAccessNoSuchFile() throws Exception {
         final HttpsFileSystemProvider https = new HttpsFileSystemProvider();
-        final HttpPath path = https.getPath(getGithubPagesFileUrl("no_exists.txt").toURI());
+        final HttpPath path = https.getPath(getGithubPagesFileUri("no_exists.txt"));
         https.checkAccess(path, AccessMode.READ);
     }
 

--- a/src/test/java/org/broadinstitute/http/nio/HttpSeekableByteChannelUnitTest.java
+++ b/src/test/java/org/broadinstitute/http/nio/HttpSeekableByteChannelUnitTest.java
@@ -6,7 +6,8 @@ import org.testng.annotations.Test;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonWritableChannelException;
@@ -20,24 +21,22 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
-/**
- * @author Daniel Gomez-Sanchez (magicDGS)
- */
-public class URLSeekableByteChannelUnitTest extends BaseTest {
-
+public class HttpSeekableByteChannelUnitTest extends BaseTest {
     public static final String LARGE_FILE_ON_GOOGLE = "https://storage.googleapis.com/hellbender/test/resources/benchmark/CEUTrio.HiSeq.WEx.b37.NA12892.bam";
     public static final String BIG_TXT_GOOGLE = "https://storage.googleapis.com/hellbender/test/resources/nio/big.txt";
     public static final String BIG_TXT_LOCAL = "testdata/big.txt";
 
+    private SeekableByteChannel getChannel(URI uri) throws IOException {
+        return new HttpSeekableByteChannel(uri);
+    }
     @Test(expectedExceptions = FileNotFoundException.class)
     public void testNonExistentUrl() throws Exception {
-        new URLSeekableByteChannel(getGithubPagesFileUrl("not_existent.txt"));
+        getChannel(getGithubPagesFileUri("not_existent.txt"));
     }
 
     @Test
     public void testNonWritableChannelExceptions() throws Exception {
-        try (final URLSeekableByteChannel channel =
-                new URLSeekableByteChannel(getGithubPagesFileUrl("file1.txt"))) {
+        try (final SeekableByteChannel channel = getChannel(getGithubPagesFileUri("file1.txt"))) {
             // cannot write
             Assert.assertThrows(NonWritableChannelException.class,
                     () -> channel.write(ByteBuffer.allocate(10)));
@@ -48,20 +47,20 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
 
     @Test(dataProvider = "getDocsFilesForTesting", dataProviderClass = GitHubResourcesIntegrationTest.class)
     public void testSize(final String fileName) throws Exception {
-        final URL urlFile = getGithubPagesFileUrl(fileName);
+        final URI urlFile = getGithubPagesFileUri(fileName);
         final Path localFile = getLocalDocsFilePath(fileName);
-        try (final URLSeekableByteChannel urlChannel = new URLSeekableByteChannel(urlFile);
-                final SeekableByteChannel localChannel = Files.newByteChannel(localFile)) {
+        try (final SeekableByteChannel urlChannel = getChannel(urlFile);
+             final SeekableByteChannel localChannel = Files.newByteChannel(localFile)) {
             Assert.assertEquals(urlChannel.size(), localChannel.size());
         }
     }
 
     @Test(dataProvider = "getDocsFilesForTesting", dataProviderClass = GitHubResourcesIntegrationTest.class)
     public void testSizeAfterRead(final String fileName) throws Exception {
-        final URL urlFile = getGithubPagesFileUrl(fileName);
+        final URI urlFile = getGithubPagesFileUri(fileName);
         final Path localFile = getLocalDocsFilePath(fileName);
-        try (final URLSeekableByteChannel urlChannel = new URLSeekableByteChannel(urlFile);
-                final SeekableByteChannel localChannel = Files.newByteChannel(localFile)) {
+        try (final SeekableByteChannel urlChannel = getChannel(urlFile);
+             final SeekableByteChannel localChannel = Files.newByteChannel(localFile)) {
 
             // use the local channel size to read
             testReadSize((int) localChannel.size(),
@@ -75,10 +74,10 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
 
     @Test(dataProvider = "getDocsFilesForTesting", dataProviderClass = GitHubResourcesIntegrationTest.class)
     public void testCachedSize(final String fileName) throws Exception {
-        final URL urlFile = getGithubPagesFileUrl(fileName);
+        final URI urlFile = getGithubPagesFileUri(fileName);
         final Path localFile = getLocalDocsFilePath(fileName);
-        try (final URLSeekableByteChannel urlChannel = new URLSeekableByteChannel(urlFile);
-                final SeekableByteChannel localChannel = Files.newByteChannel(localFile)) {
+        try (final SeekableByteChannel urlChannel = getChannel(urlFile);
+             final SeekableByteChannel localChannel = Files.newByteChannel(localFile)) {
 
             // test that the size before reading is the same (is cached)
             Assert.assertEquals(urlChannel.size(), localChannel.size());
@@ -96,8 +95,7 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
     @Test
     public void testGetPosition() throws Exception {
         // open channel
-        try (final URLSeekableByteChannel channel =
-                new URLSeekableByteChannel(getGithubPagesFileUrl("file1.txt"))) {
+        try (final SeekableByteChannel channel = getChannel(getGithubPagesFileUri("file1.txt"))) {
             int currentPosition = 0;
             Assert.assertEquals(channel.position(), currentPosition);
             final int bufferSize = Math.round(channel.size() / 10f);
@@ -112,69 +110,13 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testIllegalPosition() throws Exception {
-        new URLSeekableByteChannel(getGithubPagesFileUrl("file1.txt")).position(-1);
-    }
-
-    @DataProvider
-    public Iterator<Object[]> seekData() {
-        return Stream.of(GitHubResourcesIntegrationTest.getDocsFilesForTesting())
-                .map(data -> (String) data[0]).map(fileName ->
-                        new Object[] {
-                                getGithubPagesFileUrl(fileName), // URL
-                                10,                              // position to seek
-                                getLocalDocsFilePath(fileName)   // local file
-                        }).iterator();
-    }
-
-    @Test(dataProvider = "seekData")
-    public void testSeekBeforeRead(final URL testUrl, final long position, final Path localFile)
-            throws Exception {
-        try (final URLSeekableByteChannel actual = new URLSeekableByteChannel(testUrl);
-                final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
-            testReadSize((int) expected.size(),
-                    actual.position(position),
-                    expected.position(position));
+        try(SeekableByteChannel channel = getChannel(getGithubPagesFileUri("file1.txt"))) {
+            channel.position(-1);
         }
     }
 
-    @Test(dataProvider = "seekData")
-    public void testSeekToBeginning(final URL testUrl, final long position, final Path localFile)
-            throws Exception {
-        try (final URLSeekableByteChannel actual = new URLSeekableByteChannel(testUrl);
-                final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
-            testReadSize((int) expected.size(),
-                    // first position and then come back to 0
-                    actual.position(position).position(0),
-                    expected);
-        }
-    }
-
-    @Test(dataProvider = "seekData")
-    public void testSeekToSamePosition(final URL testUrl, final long position, final Path localFile)
-            throws Exception {
-        try (final URLSeekableByteChannel actual = new URLSeekableByteChannel(testUrl);
-                final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
-            testReadSize((int) expected.size(),
-                    // seek twice to the same position is equal to seek only once
-                    actual.position(position).position(position),
-                    expected.position(position));
-        }
-    }
-
-    @Test(dataProvider = "seekData")
-    public void testSeekShouldReopen(final URL testUrl, final long position, final Path localFile)
-            throws Exception {
-        try (final URLSeekableByteChannel actual = new URLSeekableByteChannel(testUrl);
-                final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
-            testReadSize((int) expected.size(),
-                    // seek first to 10 bytes more, and then to the requested position
-                    actual.position(position + 10).position(position),
-                    expected.position(position));
-        }
-    }
-
-    private static void testReadSize(final int size,
-            final URLSeekableByteChannel actual, final SeekableByteChannel expected)
+    protected static void testReadSize(final int size,
+                                       final SeekableByteChannel actual, final SeekableByteChannel expected)
             throws Exception {
         final ByteBuffer expectedBuffer = ByteBuffer.allocate(size);
         final ByteBuffer actualBuffer = ByteBuffer.allocate(size);
@@ -188,11 +130,81 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
                 "different byte[] after read");
     }
 
+    public static byte[] readAll(int length, ReadableByteChannel channel) throws IOException {
+        final ByteBuffer buff = ByteBuffer.allocate(length);
+        int read = 0;
+        while (read < length) {
+            final int lastRead = channel.read(buff);
+            if (lastRead == -1) {
+                break;
+            }
+            read += lastRead;
+        }
+        return buff.array();
+    }
+
+    @DataProvider
+    public Iterator<Object[]> seekData() {
+        return Stream.of(GitHubResourcesIntegrationTest.getDocsFilesForTesting())
+                .map(data -> (String) data[0]).map(fileName ->
+                        new Object[]{
+                                getGithubPagesFileUri(fileName), // URL
+                                10,                              // position to seek
+                                getLocalDocsFilePath(fileName)   // local file
+                        }).iterator();
+    }
+
+    @Test(dataProvider = "seekData")
+    public void testSeekBeforeRead(final URI testURI, final long position, final Path localFile)
+            throws Exception {
+        try (final SeekableByteChannel actual = getChannel(testURI);
+             final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
+            HttpSeekableByteChannelUnitTest.testReadSize((int) expected.size(),
+                    actual.position(position),
+                    expected.position(position));
+        }
+    }
+
+    @Test(dataProvider = "seekData")
+    public void testSeekToBeginning(final URI testURI, final long position, final Path localFile)
+            throws Exception {
+        try (final SeekableByteChannel actual = getChannel(testURI);
+             final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
+            HttpSeekableByteChannelUnitTest.testReadSize((int) expected.size(),
+                    // first position and then come back to 0
+                    actual.position(position).position(0),
+                    expected);
+        }
+    }
+
+    @Test(dataProvider = "seekData")
+    public void testSeekToSamePosition(final URI testURI, final long position, final Path localFile)
+            throws Exception {
+        try (final SeekableByteChannel actual = getChannel(testURI);
+             final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
+            HttpSeekableByteChannelUnitTest.testReadSize((int) expected.size(),
+                    // seek twice to the same position is equal to seek only once
+                    actual.position(position).position(position),
+                    expected.position(position));
+        }
+    }
+
+    @Test(dataProvider = "seekData")
+    public void testSeekShouldReopen(final URI testURI, final long position, final Path localFile)
+            throws Exception {
+        try (final SeekableByteChannel actual = getChannel(testURI);
+             final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
+            HttpSeekableByteChannelUnitTest.testReadSize((int) expected.size(),
+                    // seek first to 10 bytes more, and then to the requested position
+                    actual.position(position + 10).position(position),
+                    expected.position(position));
+        }
+    }
+
     @Test
     public void testClose() throws Exception {
         // open channel
-        final URLSeekableByteChannel channel = new URLSeekableByteChannel(
-                getGithubPagesFileUrl("file1.txt"));
+        final SeekableByteChannel channel = getChannel(getGithubPagesFileUri("file1.txt"));
         Assert.assertTrue(channel.isOpen());
         // close channel
         channel.close();
@@ -209,18 +221,19 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
     }
 
     @Test
-    public void testPositionOnGoogleFile() throws IOException {
-        URL url = new URL(LARGE_FILE_ON_GOOGLE);
-        try(URLSeekableByteChannel channel = new URLSeekableByteChannel(url)) {
+    public void testPositionOnGoogleFile() throws IOException, URISyntaxException {
+        URI URI = new URI(LARGE_FILE_ON_GOOGLE);
+        try (SeekableByteChannel channel = getChannel(URI)) {
             channel.position(10000);
             channel.read(ByteBuffer.allocate(100));
         }
     }
 
-    @Test(timeOut=10_000L) //time out if it's taking over 10 seconds to read, that indicates we're probably not skipping correctly
-    public void testReadAtEndOfLargeFileIsFast() throws IOException {
-        URL url = new URL(LARGE_FILE_ON_GOOGLE);
-        try(URLSeekableByteChannel channel = new URLSeekableByteChannel(url)) {
+    @Test(timeOut = 10_000L)
+    //time out if it's taking over 10 seconds to read, that indicates we're probably not skipping correctly
+    public void testReadAtEndOfLargeFileIsFast() throws IOException, URISyntaxException {
+        URI URI = new URI(LARGE_FILE_ON_GOOGLE);
+        try (SeekableByteChannel channel = getChannel(URI)) {
             long size = channel.size();
             Assert.assertEquals(size, 31710132189L);
             channel.position(size - 200);
@@ -228,61 +241,47 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
         }
     }
 
-
     @DataProvider
-    public Object[][] stepSize(){
-        return new Object[][]{{100},{1_000}, {10_000}, {100_000}, {1_000_000}};
+    public Object[][] stepSize() {
+        return new Object[][]{{100}, {1_000}, {10_000}, {100_000}, {1_000_000}};
     }
 
     @Test(dataProvider = "stepSize")
-    public void testDataIsConsistentForward(int stepSize) throws IOException {
-        URL url = new URL(BIG_TXT_GOOGLE);
-        try(final URLSeekableByteChannel remote = new URLSeekableByteChannel(url);
-            final SeekableByteChannel local = Files.newByteChannel(Paths.get(BIG_TXT_LOCAL))){
-            while( remote.position() < remote.size()) {
+    public void testDataIsConsistentForward(int stepSize) throws IOException, URISyntaxException {
+        URI URI = new URI(BIG_TXT_GOOGLE);
+        try (final SeekableByteChannel remote = getChannel(URI);
+             final SeekableByteChannel local = Files.newByteChannel(Paths.get(BIG_TXT_LOCAL))) {
+            while (remote.position() < remote.size()) {
                 System.out.println("pos: " + remote.position() + " size: " + remote.size());
-                Assert.assertEquals(readAll(stepSize, remote), readAll(stepSize, local));
+                Assert.assertEquals(HttpSeekableByteChannelUnitTest.readAll(stepSize, remote), HttpSeekableByteChannelUnitTest.readAll(stepSize, local));
             }
         }
     }
 
     @DataProvider
-    public Object[][] steps(){
+    public Object[][] steps() {
         return new Object[][]{
-            { Arrays.asList(1, 100, 1000, 10000, 100_000) },
-            { Arrays.asList(100_000, 10_000, 1_000, 100, 1, 0)},
+                {Arrays.asList(1, 100, 1000, 10000, 100_000)},
+                {Arrays.asList(100_000, 10_000, 1_000, 100, 1, 0)},
                 {Arrays.asList(1000, 999, 1000, 999, 1000, 999)},
-                {Arrays.asList(0,1,2,3,4,5,6,7,8,9,8,7,6,5,4,3,2,1,0)},
-                {Arrays.asList(100,151, 10_000, 824823, 10_000,151, 100)}
+                {Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)},
+                {Arrays.asList(100, 151, 10_000, 824823, 10_000, 151, 100)}
         };
     }
 
     @Test(dataProvider = "steps")
-    public void testDataIsConsistentWhileSeeking(List<Integer> positions) throws IOException {
-        URL url = new URL(BIG_TXT_GOOGLE);
+    public void testDataIsConsistentWhileSeeking(List<Integer> positions) throws IOException, URISyntaxException {
+        URI URI = new URI(BIG_TXT_GOOGLE);
         final int readlength = 100;
-        try(final URLSeekableByteChannel remote = new URLSeekableByteChannel(url);
-            final SeekableByteChannel local = Files.newByteChannel(Paths.get(BIG_TXT_LOCAL))){
-            for(int position : positions){
+        try (final SeekableByteChannel remote = getChannel(URI);
+             final SeekableByteChannel local = Files.newByteChannel(Paths.get(BIG_TXT_LOCAL))) {
+            for (int position : positions) {
                 remote.position(position);
                 local.position(position);
-                System.out.println("Start pos: " + remote.position()+ " size: " + remote.size());
-                Assert.assertEquals(readAll(readlength, remote), readAll(readlength, local));
-                System.out.println("End pos: " + remote.position()+ " size: " + remote.size());
+                System.out.println("Start pos: " + remote.position() + " size: " + remote.size());
+                Assert.assertEquals(HttpSeekableByteChannelUnitTest.readAll(readlength, remote), HttpSeekableByteChannelUnitTest.readAll(readlength, local));
+                System.out.println("End pos: " + remote.position() + " size: " + remote.size());
             }
         }
-    }
-
-    public static byte[] readAll(int length, ReadableByteChannel channel) throws IOException {
-        final ByteBuffer buff = ByteBuffer.allocate(length);
-        int read = 0;
-        while( read < length) {
-            final int lastRead = channel.read(buff);
-            if (lastRead == -1){
-                break;
-            }
-            read+= lastRead;
-        }
-        return buff.array();
     }
 }

--- a/src/test/java/org/broadinstitute/http/nio/HttpUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/http/nio/HttpUtilsUnitTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.http.HttpClient;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
@@ -50,16 +51,16 @@ public class HttpUtilsUnitTest extends BaseTest {
 
     @Test(dataProvider = "getDocsFilesForTesting", dataProviderClass = GitHubResourcesIntegrationTest.class)
     public void testExistingUrls(final String fileName) throws IOException {
-        Assert.assertTrue(HttpUtils.exists(getGithubPagesFileUrl(fileName)));
+        Assert.assertTrue(HttpUtils.exists(getGithubPagesFileUri(fileName), HttpClient.newHttpClient()));
     }
 
     @DataProvider
     public Object[][] nonExistantUrlStrings() {
         return new Object[][] {
                 // unknown host
-                {"http://www.unknown_host.com"},
+                {"http://www.doesntexist.invalid"},
                 // non existant resource
-                {"http://www.example.com/non_existant.html"}
+                {"http://www.example.com/nonexistant.html"}
         };
     }
 
@@ -67,7 +68,7 @@ public class HttpUtilsUnitTest extends BaseTest {
     // probably other home internet providers fail too
     @Test(dataProvider = "nonExistantUrlStrings")
     public void testNonExistingUrl(final String urlString) throws IOException {
-        final URL nonExistant = URI.create(urlString).toURL();
-        Assert.assertFalse(HttpUtils.exists(nonExistant));
+        final URI nonExistant = URI.create(urlString);
+            Assert.assertFalse(HttpUtils.exists(nonExistant, HttpClient.newHttpClient()));
     }
 }


### PR DESCRIPTION
* renamed URLSeekableByteChannel to HttpSeekableByteChannel
* changed some error cases to report UnsupportedOperation instead of AccessDenied
* throw on cases where a file subrange was requested but the server returns the entire file instead this is allowed but it would be complicated for us to handle
* some associated refactoring